### PR TITLE
Added support to architecture x86_64 and screenshots

### DIFF
--- a/vlc-2.1.x/Makefile
+++ b/vlc-2.1.x/Makefile
@@ -10,6 +10,16 @@ VLC_PLUGIN_LIBS := $(shell pkg-config --libs vlc-plugin)
 libdir = $(PREFIX)/lib
 plugindir = $(libdir)/vlc/plugins
 
+# Only for the O.S. Slackware
+ARCH=$(shell uname -m)
+slackwareTest=$(shell cat /etc/*-release | grep "Slackware" | wc -l)
+ifeq ($(ARCH), x86_64)
+    ifneq ($(slackwareTest), 0)
+        libdir = $(PREFIX)/lib64
+        plugindir = $(libdir)/vlc/plugins
+    endif
+endif
+
 override CC += -std=gnu99
 override CPPFLAGS += -DPIC -I. -Isrc
 override CFLAGS += -fPIC

--- a/vlc-2.2.x+/Makefile
+++ b/vlc-2.2.x+/Makefile
@@ -10,6 +10,16 @@ VLC_PLUGIN_LIBS := $(shell pkg-config --libs vlc-plugin)
 libdir = $(PREFIX)/lib
 plugindir = $(libdir)/vlc/plugins
 
+# Only for the O.S. Slackware
+ARCH=$(shell uname -m)
+slackwareTest=$(shell cat /etc/*-release | grep "Slackware" | wc -l)
+ifeq ($(ARCH), x86_64)
+    ifneq ($(slackwareTest), 0)
+        libdir = $(PREFIX)/lib64
+        plugindir = $(libdir)/vlc/plugins
+    endif
+endif
+
 override CC += -std=gnu99
 override CPPFLAGS += -DPIC -I. -Isrc
 override CFLAGS += -fPIC


### PR DESCRIPTION
Hello,
I was trying your plugin in my laptop (running Slackware 14.1 X86_64, and doesn't worked because it was just for architecture x86 ( or libdir = /usr/lib/), so I decided to add x86_64, just two ifeq (and make a fork and a pull request, if you think it's good, accept);

Thank you for the awesome plugin! See you.

Commit:
"Added support to architecture x86_64.
Tested in one Slackware 14.1
Added two screenshots to make more easy to enable the plugin."