### PR TITLE
Added openSUSE x86_64 support

### DIFF
--- a/vlc-2.1.x/Makefile
+++ b/vlc-2.1.x/Makefile
@@ -9,11 +9,11 @@ VLC_PLUGIN_LIBS := $(shell pkg-config --libs vlc-plugin)
 
 libdir = $(PREFIX)/lib
 
-# Slackware uses /usr/lib64 on x86_64
+# Slackware and openSUSE use /usr/lib64 on x86_64
 ARCH=$(shell uname -m)
 ifeq ($(ARCH), x86_64)
-    slackwareTest=$(shell cat /etc/*-release | grep "Slackware" | wc -l)
-    ifneq ($(slackwareTest), 0)
+    lib64Test=$(shell grep -E "Slackware|openSUSE" /etc/*-release | wc -l)
+    ifneq ($(lib64Test), 0)
         libdir = $(PREFIX)/lib64
     endif
 endif

--- a/vlc-2.2.x+/Makefile
+++ b/vlc-2.2.x+/Makefile
@@ -9,11 +9,11 @@ VLC_PLUGIN_LIBS := $(shell pkg-config --libs vlc-plugin)
 
 libdir = $(PREFIX)/lib
 
-# Slackware uses /usr/lib64 on x86_64
+# Slackware and openSUSE use /usr/lib64 on x86_64
 ARCH=$(shell uname -m)
 ifeq ($(ARCH), x86_64)
-    slackwareTest=$(shell cat /etc/*-release | grep "Slackware" | wc -l)
-    ifneq ($(slackwareTest), 0)
+    lib64Test=$(shell grep -E "Slackware|openSUSE" /etc/*-release | wc -l)
+    ifneq ($(lib64Test), 0)
         libdir = $(PREFIX)/lib64
     endif
 endif


### PR DESCRIPTION
Like Slackware, openSUSE uses also /usr/lib64 on x86_64
cat command is not needed