### PR TITLE
Only pause/play on left double-click if left button is selected

### DIFF
--- a/vlc-2.1.x/pause_click.c
+++ b/vlc-2.1.x/pause_click.c
@@ -96,7 +96,14 @@ int mouse(filter_t *p_filter, vlc_mouse_t *p_mouse_out, const vlc_mouse_t *p_mou
     int mouse_button = FROM_CHAR(mouse_button_value[0]);
     free(mouse_button_value);
 
-    if (vlc_mouse_HasPressed(p_mouse_old, p_mouse_new, mouse_button) || p_mouse_new->b_double_click) {
+    int triggered = 0;
+    if (mouse_button == MOUSE_BUTTON_LEFT) {
+        triggered = vlc_mouse_HasPressed(p_mouse_old, p_mouse_new, mouse_button) || p_mouse_new->b_double_click;
+    } else {
+        triggered = vlc_mouse_HasPressed(p_mouse_old, p_mouse_new, mouse_button);
+    }
+
+    if (triggered) {
         playlist_t* p_playlist = pl_Get((vlc_object_t *)p_filter);
         playlist_Control(p_playlist,
                          (playlist_Status(p_playlist) == PLAYLIST_RUNNING ? PLAYLIST_PAUSE : PLAYLIST_PLAY), 0);

--- a/vlc-2.2.x+/pause_click.c
+++ b/vlc-2.2.x+/pause_click.c
@@ -105,8 +105,14 @@ int mouse(filter_t *p_filter, vlc_mouse_t *p_mouse_out, const vlc_mouse_t *p_mou
     int mouse_button = FROM_CHAR(mouse_button_value[0]);
     free(mouse_button_value);
 
-    if (p_intf != NULL &&
-            (vlc_mouse_HasPressed(p_mouse_old, p_mouse_new, mouse_button) || p_mouse_new->b_double_click)) {
+    int triggered = 0;
+    if (mouse_button == MOUSE_BUTTON_LEFT) {
+        triggered = vlc_mouse_HasPressed(p_mouse_old, p_mouse_new, mouse_button) || p_mouse_new->b_double_click;
+    } else {
+        triggered = vlc_mouse_HasPressed(p_mouse_old, p_mouse_new, mouse_button);
+    }
+
+    if (p_intf != NULL && triggered) {
         playlist_t* p_playlist = pl_Get(p_intf);
         playlist_Control(p_playlist,
                          (playlist_Status(p_playlist) == PLAYLIST_RUNNING ? PLAYLIST_PAUSE : PLAYLIST_PLAY), 0);


### PR DESCRIPTION
If you select another button than left for pause/play action, playstate changes from play to pause (or the other way round) when toggling fullscreen via left double-click.

Added a check to only pause/play on left double-click if left button is selected.