### PR TITLE
Add .gitattributes for *.sh files to fix CRLF/LF conversion issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh eol=lf


### PR DESCRIPTION
Since some Windows git client has CRLF as default EOL conversion, it'd be nice to have explicit `.gitattributes` for `*.sh` files.

Without this .gitiattributes, you may see something like the following issue:
https://askubuntu.com/questions/1044280/set-eo-pipefail-not-working-in-windows-subsystem-for-linux-ubuntu-16-04

You can check this PR with the following command in Windows PowerShell terminal:

```
cd ~
git clone -b fix-eol https://github.com/t-mat/vlc-pause-click-plugin.git fix-eol
cd fix-eol
docker build -t vlc-pause-click-plugin-windows-build-fix-eol docker
docker run --rm -v "${PWD}:/repo" -v "${PWD}/build:/build" vlc-pause-click-plugin-windows-build-fix-eol all
```
